### PR TITLE
fix: support utf-8 characters in DB query results

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -137,6 +137,9 @@ export class App {
 			password: getConfig().db.password,
 			database: getConfig().db.database,
 			entities: [`${__dirname}/models/db/**/*{.js,.ts}`],
+			extra: {
+				charset: 'utf8mb4_unicode_ci'
+			},
 			synchronize: getConfig().environment === Environment.Dev // Note: Unsafe in production, use migrations instead
 		}
 	];


### PR DESCRIPTION
Resolves #87 

This PR fixes a bug discovered during a test run of the application platform when using unicode characters. It passes an option through Typeorm to the underlying MySQL driver to support UTF-8.

_Note: We should also create some tests to check we don't regress on this in the future._