### PR TITLE
feat: add typeorm migration support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,5 +5,5 @@ module.exports = {
 		'project': 'tsconfig.eslint.json'
 	},
 	'extends': '@unicsmcr',
-	'ignorePatterns': ["src/public/**/*.js"],
+	'ignorePatterns': ["src/public/**/*", "src/migrations"],
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm i -g codeclimate-test-reporter
+    - run: cp .env.example .env
     - run: make ci
     - run: bash <(curl -s https://codecov.io/bash)
       env:

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "test:coverage": "jest -i --coverage --forceExit",
     "start": "ts-node --files src/server.ts | pino-http-print -a -r -t 'yyyy-mm-dd HH:MM:ss.l'",
     "start:watch": "node ./node_modules/nodemon/bin/nodemon.js",
-    "lint": "eslint src test --ignore-pattern \"src/public/**/*\" --ext .ts",
-    "lint:fix": "eslint src test --ignore-pattern \"src/public/**/*\" --ext .ts --fix"
+    "lint": "eslint src test --ext .ts",
+    "lint:fix": "eslint src test --ext .ts --fix",
+    "typeorm": "ts-node --files ./node_modules/typeorm/cli.js -f ./src/ormconfig.ts"
   },
   "repository": {
     "type": "GitHub",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,15 +1,16 @@
 import 'reflect-metadata';
 
 // Need to load the .env file BEFORE loading the ORM config
+import { Environment, getConfig } from './util/config';
 import dotenv from 'dotenv';
 dotenv.config({ path: '.env' });
+getConfig(process.env);
 
 import config from './ormconfig';
 
 import { initializeTransactionalContext } from 'typeorm-transactional-cls-hooked';
 initializeTransactionalContext(); // Initialize cls-hooked
 
-import { Environment, getConfig } from './util/config';
 import path from 'path';
 import cookieParser from 'cookie-parser';
 import helmet from 'helmet';

--- a/src/migrations/1603916017796-InitialSetup.ts
+++ b/src/migrations/1603916017796-InitialSetup.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InitialSetup1603916017796 implements MigrationInterface {
+	name = 'InitialSetup1603916017796';
+
+	public async up(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query('CREATE TABLE `partial_applicant` (`authId` varchar(255) NOT NULL, `partialApplication` json NOT NULL, `lastModified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`authId`)) ENGINE=InnoDB', undefined);
+		await queryRunner.query('CREATE TABLE `review` (`id` varchar(36) NOT NULL, `createdByAuthID` varchar(255) NOT NULL, `averageScore` int NOT NULL, `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, `applicantId` varchar(36) NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB', undefined);
+		await queryRunner.query("CREATE TABLE `applicant` (`id` varchar(36) NOT NULL, `authId` varchar(255) NULL, `age` int NOT NULL, `gender` varchar(255) NOT NULL, `nationality` varchar(255) NULL, `country` varchar(255) NOT NULL, `city` varchar(255) NOT NULL, `university` varchar(255) NOT NULL, `degree` varchar(255) NOT NULL, `yearOfStudy` varchar(255) NOT NULL, `cv` varchar(255) NULL, `workArea` varchar(255) NULL, `skills` varchar(255) NULL, `hackathonCount` int NULL, `whyChooseHacker` text NULL, `pastProjects` text NULL, `hardwareRequests` text NULL, `dietaryRequirements` varchar(255) NOT NULL, `tShirtSize` varchar(255) NOT NULL, `hearAbout` varchar(255) NOT NULL, `inviteAcceptDeadline` datetime NULL, `applicationStatus` enum ('0', '1', '2', '3', '4', '5', '6', '7') NOT NULL DEFAULT '1', `createdAt` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE INDEX `IDX_1190863787a09bdc332796d622` (`authId`), PRIMARY KEY (`id`)) ENGINE=InnoDB", undefined);
+		await queryRunner.query('ALTER TABLE `review` ADD CONSTRAINT `FK_530b8666ff790e4e0e00bb41669` FOREIGN KEY (`applicantId`) REFERENCES `applicant`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION', undefined);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<any> {
+		await queryRunner.query('ALTER TABLE `review` DROP FOREIGN KEY `FK_530b8666ff790e4e0e00bb41669`', undefined);
+		await queryRunner.query('DROP INDEX `IDX_1190863787a09bdc332796d622` ON `applicant`', undefined);
+		await queryRunner.query('DROP TABLE `applicant`', undefined);
+		await queryRunner.query('DROP TABLE `review`', undefined);
+		await queryRunner.query('DROP TABLE `partial_applicant`', undefined);
+	}
+}

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -1,0 +1,22 @@
+import { ConnectionOptions } from 'typeorm';
+import { getConfig, Environment } from './util/config';
+
+const config: ConnectionOptions = {
+	type: 'mysql',
+	host: getConfig().db.host,
+	port: getConfig().db.port,
+	username: getConfig().db.user,
+	password: getConfig().db.password,
+	database: getConfig().db.database,
+	entities: [`${__dirname}/models/db/**/*{.js,.ts}`],
+	extra: {
+		charset: 'utf8mb4_unicode_ci'
+	},
+	migrations: ['src/migration/*.ts'],
+	cli: {
+		migrationsDir: 'src/migrations'
+	},
+	synchronize: getConfig().environment === Environment.Dev // Note: Unsafe in production, use migrations instead
+};
+
+export = config;

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -52,7 +52,9 @@ test('App should start in production environment', async () => {
  * Testing error handling with incorrect settings
  */
 test('App should throw error with invalid settings', async () => {
-	process.env.DB_HOST = 'invalidhost';
-	await expect(new App().buildApp()).rejects.toThrow();
+	const testOptions = getTestDatabaseOptions();
+	Object.assign(testOptions[0], { host: 'invalidhost' });
+
+	await expect(new App().buildApp(testOptions)).rejects.toThrow();
 	expect(getConnection().isConnected).toBeFalsy();
 });


### PR DESCRIPTION
Resolves #86 

This PR adds support for Typeorm Migrations, it removes the need for using the `synchronize` typeorm option which is unsafe in production. I have included an auto-generated migration for the schema which is included in the `src/migration` folder.

Whenever a change to one of the database entities is made, you should generate a new migration to be used in production. The migrations are applied sequentially based on the timestamp in the filename.