### PR TITLE
test: invite controller tests

### DIFF
--- a/src/controllers/inviteController.ts
+++ b/src/controllers/inviteController.ts
@@ -16,7 +16,7 @@ export interface InviteControllerInterface {
 }
 
 export enum ConfirmMessageEnum {
-	Invalid = 'The invite is on longer valid.',
+	Invalid = 'The invite is no longer valid.',
 	Expired = 'This invite has expired, we\'re sorry you have missed the deadline.',
 	Confirmed = 'Thank you! Your attendence has been confirmed!',
 	Error = 'An error occured, please try again or contact us for help'

--- a/src/controllers/inviteController.ts
+++ b/src/controllers/inviteController.ts
@@ -15,6 +15,19 @@ export interface InviteControllerInterface {
 	confirm: (req: Request, res: Response, next: NextFunction) => void;
 }
 
+export enum ConfirmMessageEnum {
+	Invalid = 'The invite is on longer valid.',
+	Expired = 'This invite has expired, we\'re sorry you have missed the deadline.',
+	Confirmed = 'Thank you! Your attendence has been confirmed!',
+	Error = 'An error occured, please try again or contact us for help'
+}
+
+export enum SendMessageEnum {
+	Failed = 'Applicant cannot be invited yet',
+	Success = 'Sent invite successfully!',
+	Error = 'Failed to send invite'
+}
+
 /**
  * A controller for dashboard methods
  */
@@ -168,7 +181,7 @@ export class InviteController extends CommonController implements InviteControll
 			applicant = await this._applicantService.findOne(req.params.id, 'id');
 		} catch (err) {
 			res.status(HttpResponseCode.BAD_REQUEST).send({
-				message: 'Failed to send invite'
+				message: SendMessageEnum.Error
 			});
 			return;
 		}
@@ -177,11 +190,11 @@ export class InviteController extends CommonController implements InviteControll
 		const result: boolean = await this.sendInvite(req, applicant);
 		if (result) {
 			res.send({
-				message: 'Sent invite successfully!'
+				message: SendMessageEnum.Success
 			});
 		} else {
 			res.send({
-				message: 'Applicant cannot be invited yet!'
+				message: SendMessageEnum.Failed
 			});
 		}
 	}
@@ -197,23 +210,23 @@ export class InviteController extends CommonController implements InviteControll
 
 		let notifyMessage: string;
 		if (applicant.applicationStatus >= ApplicantStatus.Confirmed) {
-			notifyMessage = 'The invite is on longer valid.';
+			notifyMessage = ConfirmMessageEnum.Invalid;
 		} else if (applicant.inviteAcceptDeadline && applicant.inviteAcceptDeadline.getTime() <= new Date().getTime()) {
 			// Check that the invite deadline has not expired
-			notifyMessage = "This invite has expired, we're sorry you have missed the deadline.";
+			notifyMessage = ConfirmMessageEnum.Expired;
 			applicant.applicationStatus = ApplicantStatus.Rejected;
 		} else if (reqUser.id === applicant.authId && applicant.applicationStatus === ApplicantStatus.Invited) {
 			// Check that the logged in user can be invited
-			notifyMessage = 'Thank you! Your attendence has been confirmed!';
+			notifyMessage = ConfirmMessageEnum.Confirmed;
 			applicant.applicationStatus = ApplicantStatus.Confirmed;
 		} else {
-			notifyMessage = 'An error occured, please try again or contact us for help';
+			notifyMessage = ConfirmMessageEnum.Error;
 		}
 
 		try {
 			await this._applicantService.save(applicant);
 		} catch (err) {
-			notifyMessage = 'An error occured! Please contact us for help';
+			notifyMessage = ConfirmMessageEnum.Error;
 		}
 
 		void super.renderPage(req, res, pages.notify, {

--- a/test/integration/invite/inviteController.test.ts
+++ b/test/integration/invite/inviteController.test.ts
@@ -1,0 +1,229 @@
+import { initEnv, getTestDatabaseOptions } from '../../util/testUtils';
+import { mockFrontendRenderer, mockRequestAuthentication, mockSettingsLoader, mockHackathonConfigCache } from '../../util/mocks';
+
+import request from 'supertest';
+import { App } from '../../../src/app';
+import { Express } from 'express';
+import { HttpResponseCode } from '../../../src/util/errorHandling';
+import { instance, mock, when, reset } from 'ts-mockito';
+import { RequestAuthentication, SettingLoader } from '../../../src/util';
+import { ApplicantService, EmailService } from '../../../src/services';
+import { Applicant } from '../../../src/models/db';
+import { Cache } from '../../../src/util/cache';
+
+import container from '../../../src/inversify.config';
+import { ApplicantStatus } from '../../../src/services/applications/applicantStatus';
+import { SendMessageEnum, ConfirmMessageEnum } from '../../../src/controllers/inviteController';
+
+let bApp: Express;
+let mockRequestAuth: RequestAuthentication;
+let mockSettingLoader: SettingLoader;
+let mockCache: Cache;
+let mockApplicantService: ApplicantService;
+let mockEService: EmailService;
+
+const requestUser = {
+	name: 'Test',
+	email: 'test@test.com',
+	id: '010eee101'
+};
+
+const testApplicant1: Applicant = new Applicant();
+testApplicant1.authId = requestUser.id;
+testApplicant1.age = 20;
+testApplicant1.gender = 'Test';
+testApplicant1.nationality = 'UK';
+testApplicant1.country = 'UK';
+testApplicant1.city = 'Manchester';
+testApplicant1.university = 'UoM';
+testApplicant1.yearOfStudy = 'Foundation';
+testApplicant1.workArea = 'This';
+testApplicant1.hackathonCount = 0;
+testApplicant1.dietaryRequirements = 'Test';
+testApplicant1.tShirtSize = 'M';
+testApplicant1.hearAbout = 'Other';
+
+let spiedRenderer: jest.SpyInstance;
+beforeAll(async () => {
+	initEnv();
+	spiedRenderer = mockFrontendRenderer();
+
+	mockRequestAuth = mockRequestAuthentication(requestUser);
+	mockSettingLoader = mockSettingsLoader();
+	mockCache = mockHackathonConfigCache();
+	mockApplicantService = mock(ApplicantService);
+	mockEService = mock(EmailService);
+
+	container.rebind(RequestAuthentication).toConstantValue(instance(mockRequestAuth));
+	container.rebind(SettingLoader).toConstantValue(instance(mockSettingLoader));
+	container.rebind(Cache).toConstantValue(instance(mockCache));
+	container.rebind(ApplicantService).toConstantValue(instance(mockApplicantService));
+	container.rebind(EmailService).toConstantValue(instance(mockEService));
+
+	bApp = await new App().buildApp(getTestDatabaseOptions());
+});
+
+beforeEach(() => {
+	// Create a snapshot so each unit test can modify it without breaking other unit tests
+	container.snapshot();
+	spiedRenderer.mockReset();
+	spiedRenderer = mockFrontendRenderer();
+});
+
+afterEach(() => {
+	// Restore to last snapshot so each unit test takes a clean copy of the container
+	container.restore();
+
+	// Reset the mocks
+	reset(mockApplicantService);
+	reset(mockEService);
+});
+
+describe('Invite controller tests for confirm route', () => {
+	beforeAll(() => {
+		// Setup email service mock
+		when(mockEService.sendEmail).thenReturn(() => Promise.resolve(true));
+	});
+
+	test('Test invite confirm request returns valid response', async () => {
+		const confirmableApplicant = new Applicant();
+		confirmableApplicant.authId = requestUser.id;
+		confirmableApplicant.applicationStatus = ApplicantStatus.Invited;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(confirmableApplicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.resolve(confirmableApplicant));
+
+		// Perform the request along /invite/123/confirm
+		const response = await request(bApp).get('/invite/123/confirm');
+
+		// Check that we get a OK (200) response code
+		expect(response.status).toBe(HttpResponseCode.OK);
+		expect(spiedRenderer.mock.calls[0][3].message).toBe(ConfirmMessageEnum.Confirmed);
+	});
+
+	test('Test invite confirm request returns valid response when invite expired', async () => {
+		const expiredApplicant = new Applicant();
+		expiredApplicant.applicationStatus = ApplicantStatus.Invited;
+		expiredApplicant.inviteAcceptDeadline = new Date(Date.now() - (60 * 60 * 1000));
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(expiredApplicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.resolve(expiredApplicant));
+
+		// Perform the request along /invite/123/confirm
+		const response = await request(bApp).get('/invite/123/confirm');
+
+		// Check that we get a OK (200) response code
+		expect(response.status).toBe(HttpResponseCode.OK);
+		expect(spiedRenderer.mock.calls[0][3].message).toBe(ConfirmMessageEnum.Expired);
+	});
+
+	test('Test invite confirm request returns valid response when already confirmed', async () => {
+		const applicant = new Applicant();
+		applicant.applicationStatus = ApplicantStatus.Confirmed;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(applicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.resolve(applicant));
+
+		// Perform the request along /invite/123/confirm
+		const response = await request(bApp).get('/invite/123/confirm');
+
+		// Check that we get a OK (200) response code
+		expect(response.status).toBe(HttpResponseCode.OK);
+		expect(spiedRenderer.mock.calls[0][3].message).toBe(ConfirmMessageEnum.Invalid);
+	});
+
+	test('Test invite confirm request returns valid response unknown state', async () => {
+		const applicant = new Applicant();
+		applicant.applicationStatus = ApplicantStatus.Invited;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(applicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.resolve(applicant));
+
+		// Perform the request along /invite/123/confirm
+		const response = await request(bApp).get('/invite/123/confirm');
+
+		// Check that we get a OK (200) response code
+		expect(response.status).toBe(HttpResponseCode.OK);
+		expect(spiedRenderer.mock.calls[0][3].message).toBe(ConfirmMessageEnum.Error);
+	});
+
+	test('Test invite confirm request returns 500 response when findOne fails', async () => {
+		when(mockApplicantService.findOne).thenReturn(() => Promise.reject());
+
+		// Perform the request along /invite/123/confirm
+		const response = await request(bApp).get('/invite/123/confirm');
+
+		// Check that we get a 500 response code
+		expect(response.status).toBe(HttpResponseCode.INTERNAL_ERROR);
+	});
+
+	test('Test invite confirm request returns error message when save fails', async () => {
+		const applicant = new Applicant();
+		applicant.applicationStatus = ApplicantStatus.Invited;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(applicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.reject());
+
+		// Perform the request along /invite/123/confirm
+		const response = await request(bApp).get('/invite/123/confirm');
+
+		// Check that we get a OK (200) response code
+		expect(response.status).toBe(HttpResponseCode.OK);
+		expect(spiedRenderer.mock.calls[0][3].message).toBe(ConfirmMessageEnum.Error);
+	});
+});
+
+describe('Invite controller tests for invite send route', () => {
+	beforeAll(() => {
+		// Setup email service mock
+		when(mockEService.sendEmail).thenReturn(() => Promise.resolve(true));
+	});
+
+	test('Test invite send request returns valid response for valid applicant states', async () => {
+		for (const state of [ApplicantStatus.Applied, ApplicantStatus.Reviewed]) {
+			const applicant = new Applicant();
+			applicant.applicationStatus = state;
+			when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(applicant));
+			when(mockApplicantService.save).thenReturn(() => Promise.resolve(applicant));
+
+			// Perform the request along /invite/123/send
+			const response = await request(bApp).put('/invite/123/send');
+
+			// Check that we get a OK (200) response code
+			expect(response.status).toBe(HttpResponseCode.OK);
+			expect(response.body.message).toBe(SendMessageEnum.Success);
+		}
+	});
+
+	test('Test invite send request returns valid response for invalid applicant state', async () => {
+		const applicant = new Applicant();
+		applicant.applicationStatus = ApplicantStatus.Rejected;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(applicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.resolve(applicant));
+
+		// Perform the request along /invite/123/send
+		const response = await request(bApp).put('/invite/123/send');
+
+		expect(response.body.message).toBe(SendMessageEnum.Failed);
+	});
+
+	test('Test invite send request returns error with thrown error on findOne', async () => {
+		const applicant = new Applicant();
+		applicant.applicationStatus = ApplicantStatus.Applied;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.reject());
+
+		// Perform the request along /invite/123/send
+		const response = await request(bApp).put('/invite/123/send');
+
+		// Check that we get a BAD_REQUEST (400) response code
+		expect(response.status).toBe(HttpResponseCode.BAD_REQUEST);
+		expect(response.body.message).toBe(SendMessageEnum.Error);
+	});
+
+	test('Test invite send request returns error with thrown error on save', async () => {
+		const applicant = new Applicant();
+		applicant.applicationStatus = ApplicantStatus.Applied;
+		when(mockApplicantService.findOne).thenReturn(() => Promise.resolve(applicant));
+		when(mockApplicantService.save).thenReturn(() => Promise.reject());
+
+		// Perform the request along /invite/123/send
+		const response = await request(bApp).put('/invite/123/send');
+
+		expect(response.body.message).toBe(SendMessageEnum.Failed);
+	});
+});


### PR DESCRIPTION
Builds upon #98 

Adds some tests for `confirm` and `send` routes on the invite controller. I didn't write tests for the `batchSend` since we may be refactoring this code soon to support the `hs_notify` service.