### PR TITLE
feat: auth v2 uri params

### DIFF
--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -33,7 +33,7 @@ export class AdminRouter implements RouterInterface {
 			this._requestAuth.withAuthMiddleware(this, this._adminController.downloadAllCVsFromDropbox)
 		);
 
-		router.get('/manage/[a-z0-9-]+',
+		router.get('/manage/:id([a-z0-9-]+)',
 			this._requestAuth.withAuthMiddleware(this, this._adminController.manageApplication));
 
 		return router;

--- a/src/util/auth/hs_auth.ts
+++ b/src/util/auth/hs_auth.ts
@@ -121,8 +121,22 @@ export class RequestAuthentication {
 		const opHandlerParts = operationHandler.name.split(' ');
 		const opHandlerName = opHandlerParts[opHandlerParts.length - 1];
 
-		const requestParams = Object.entries(req.params);
-		const args = requestParams.length > 0 ? new Map(requestParams) : undefined;
+		const args = new Map();
+
+		// Request path parameters
+		for (const [key, val] of Object.entries(req.params)) {
+			args.set(`path_${key}`, val);
+		}
+
+		// Request form parameters
+		for (const [key, val] of Object.entries(req.query)) {
+			args.set(`query_${key}`, val);
+		}
+
+		// Request form parameters
+		for (const [key, val] of Object.entries(req.body)) {
+			args.set(`postForm_${key}`, val);
+		}
 
 		return this.authApi.newUri(`${routerName}:${opHandlerName}`, args);
 	}

--- a/src/util/auth/hs_auth.ts
+++ b/src/util/auth/hs_auth.ts
@@ -116,13 +116,14 @@ export class RequestAuthentication {
 		return req.cookies[this.cookieName];
 	}
 
-	// TODO: Add arguments to the URI (See https://github.com/unicsmcr/hs_apply/issues/75)
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	private getUriFromRequest(router: RouterInterface, operationHandler: ExpressOpHandlerFunction, _req: Request): string {
+	private getUriFromRequest(router: RouterInterface, operationHandler: ExpressOpHandlerFunction, req: Request): string {
 		const routerName = Reflect.getPrototypeOf(router).constructor.name.replace('Router', '');
 		const opHandlerParts = operationHandler.name.split(' ');
 		const opHandlerName = opHandlerParts[opHandlerParts.length - 1];
 
-		return this.authApi.newUri(`${routerName}:${opHandlerName}`);
+		const requestParams = Object.entries(req.params);
+		const args = requestParams.length > 0 ? new Map(requestParams) : undefined;
+
+		return this.authApi.newUri(`${routerName}:${opHandlerName}`, args);
 	}
 }


### PR DESCRIPTION
Resolves #75 and resolves #71 

Very similar to the URI code in `hs_auth`, it checks for any URL path, query or form parameters and adds them to the URI